### PR TITLE
chore: ignore gradle wrapper jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
## Summary
- ignore gradle wrapper jar file

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a8f55fd4f88330ac0f8f9c7c685c9e