### PR TITLE
chore: update Kotlin plugin to 1.9.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
     id("com.android.application") version "8.5.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.20" apply false
 }


### PR DESCRIPTION
## Summary
- bump Kotlin plugin to version 1.9.20

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a90b297c088330858fe022f6453cf3