### PR TITLE
Add interactive Sudoku board and game flow

### DIFF
--- a/app/src/main/java/com/example/sudokugame/MainActivity.kt
+++ b/app/src/main/java/com/example/sudokugame/MainActivity.kt
@@ -3,12 +3,13 @@ package com.example.sudokugame
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.sudokugame.ui.theme.SudokuGameTheme
 
@@ -18,15 +19,45 @@ class MainActivity : ComponentActivity() {
         setContent {
             SudokuGameTheme {
                 Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                    SudokuScreen()
+                    App()
                 }
             }
         }
     }
 }
 
+private enum class Screen { Start, Game }
+
 @Composable
-fun SudokuScreen() {
+fun App() {
+    var current by remember { mutableStateOf(Screen.Start) }
+    Crossfade(targetState = current, label = "Screen") { screen ->
+        when (screen) {
+            Screen.Start -> StartScreen { current = Screen.Game }
+            Screen.Game -> GameScreen()
+        }
+    }
+}
+
+@Composable
+fun StartScreen(onStart: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Sudoku",
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(Modifier.height(24.dp))
+        Button(onClick = onStart) { Text("Start Game") }
+    }
+}
+
+@Composable
+fun GameScreen() {
     var board by remember { mutableStateOf(generateEmptyBoard()) }
     var selected by remember { mutableStateOf<Pair<Int, Int>?>(null) }
 
@@ -34,6 +65,30 @@ fun SudokuScreen() {
         Spacer(Modifier.height(16.dp))
         SudokuBoard(board, selected) { row, col ->
             selected = row to col
+        }
+        Spacer(Modifier.height(16.dp))
+        NumberPad { number ->
+            selected?.let { (r, c) ->
+                val newBoard = board.map { it.clone() }.toTypedArray()
+                newBoard[r][c] = number
+                board = newBoard
+            }
+        }
+    }
+}
+
+@Composable
+fun NumberPad(onNumberSelected: (Int) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        for (i in 1..9) {
+            Button(onClick = { onNumberSelected(i) }) {
+                Text(i.toString())
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/sudokugame/SudokuBoard.kt
+++ b/app/src/main/java/com/example/sudokugame/SudokuBoard.kt
@@ -1,9 +1,12 @@
 package com.example.sudokugame
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -11,18 +14,31 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun SudokuBoard(board: Array<IntArray>, selected: Pair<Int, Int>?, onCellTapped: (Int, Int) -> Unit) {
-    Canvas(modifier = Modifier.size(300.dp).background(Color.White)) {
+    Canvas(
+        modifier = Modifier
+            .size(300.dp)
+            .background(Color.White)
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    val cellSize = size.width / 9
+                    val col = (offset.x / cellSize).toInt().coerceIn(0, 8)
+                    val row = (offset.y / cellSize).toInt().coerceIn(0, 8)
+                    onCellTapped(row, col)
+                }
+            }
+    ) {
         val cellSize = size.width / 9
         for (r in 0 until 9) {
             for (c in 0 until 9) {
                 val x = c * cellSize
                 val y = r * cellSize
-                val isSelected = selected?.first == r && selected?.second == c
-                val alpha = if (isSelected) 0.5f else 0f
+                val isSelected = selected?.let { it.first == r && it.second == c } ?: false
+                val alpha by animateFloatAsState(if (isSelected) 0.5f else 0f)
                 drawRect(
                     color = Color.Blue.copy(alpha = alpha),
                     topLeft = Offset(x, y),


### PR DESCRIPTION
## Summary
- Integrate tap handling and animated cell highlighting in SudokuBoard
- Introduce start screen and crossfade navigation
- Add number pad for cell entry and update board state

## Testing
- `./gradlew test` *(fails: Unable to access jarfile /workspace/Sudoku-Game-Android/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_b_68a90f58c388833087642f4e61d6865d