### PR TITLE
Implement difficulty modes, timer, save/continue, notes, and settings

### DIFF
--- a/app/src/main/java/com/example/sudokugame/MainActivity.kt
+++ b/app/src/main/java/com/example/sudokugame/MainActivity.kt
@@ -1,17 +1,28 @@
 package com.example.sudokugame
 
+import android.content.Context
+import android.media.AudioManager
+import android.media.ToneGenerator
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.sudokugame.ui.theme.SudokuGameTheme
+import kotlinx.coroutines.delay
+
+enum class Screen { Start, Game, Settings }
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,21 +37,53 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-private enum class Screen { Start, Game }
-
 @Composable
 fun App() {
-    var current by remember { mutableStateOf(Screen.Start) }
-    Crossfade(targetState = current, label = "Screen") { screen ->
-        when (screen) {
-            Screen.Start -> StartScreen { current = Screen.Game }
-            Screen.Game -> GameScreen()
+    val context = LocalContext.current
+    var screen by remember { mutableStateOf(Screen.Start) }
+    var board by remember { mutableStateOf<Array<IntArray>?>(null) }
+    var time by remember { mutableStateOf(0) }
+
+    Crossfade(targetState = screen, label = "screen") { s ->
+        when (s) {
+            Screen.Start -> StartScreen(
+                hasSaved = context.getSharedPreferences("sudoku", Context.MODE_PRIVATE)
+                    .contains("board"),
+                onStart = { difficulty ->
+                    board = generatePuzzle(difficulty)
+                    time = 0
+                    screen = Screen.Game
+                },
+                onContinue = {
+                    val prefs = context.getSharedPreferences("sudoku", Context.MODE_PRIVATE)
+                    board = stringToBoard(prefs.getString("board", "") ?: "")
+                    time = prefs.getInt("time", 0)
+                    screen = Screen.Game
+                },
+                onSettings = { screen = Screen.Settings }
+            )
+            Screen.Game -> board?.let { b ->
+                GameScreen(
+                    initialBoard = b,
+                    initialTime = time,
+                    onBack = {
+                        board = null
+                        screen = Screen.Start
+                    }
+                )
+            }
+            Screen.Settings -> SettingsScreen(onBack = { screen = Screen.Start })
         }
     }
 }
 
 @Composable
-fun StartScreen(onStart: () -> Unit) {
+fun StartScreen(
+    hasSaved: Boolean,
+    onStart: (Difficulty) -> Unit,
+    onContinue: () -> Unit,
+    onSettings: () -> Unit
+) {
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -52,43 +95,180 @@ fun StartScreen(onStart: () -> Unit) {
             fontWeight = FontWeight.Bold
         )
         Spacer(Modifier.height(24.dp))
-        Button(onClick = onStart) { Text("Start Game") }
+        Row {
+            Button(onClick = { onStart(Difficulty.Easy) }) { Text("Easy") }
+            Spacer(Modifier.width(8.dp))
+            Button(onClick = { onStart(Difficulty.Medium) }) { Text("Medium") }
+            Spacer(Modifier.width(8.dp))
+            Button(onClick = { onStart(Difficulty.Hard) }) { Text("Hard") }
+        }
+        if (hasSaved) {
+            Spacer(Modifier.height(16.dp))
+            Button(onClick = onContinue) { Text("Continue") }
+        }
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = onSettings) { Text("Settings") }
     }
 }
 
 @Composable
-fun GameScreen() {
-    var board by remember { mutableStateOf(generateEmptyBoard()) }
-    var selected by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+fun GameScreen(
+    initialBoard: Array<IntArray>,
+    initialTime: Int,
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+    val prefs = context.getSharedPreferences("sudoku", Context.MODE_PRIVATE)
+    val haptic = LocalHapticFeedback.current
+    val tone = remember { ToneGenerator(AudioManager.STREAM_MUSIC, 50) }
+    val soundEnabled = prefs.getBoolean("sound", true)
+    val vibrationEnabled = prefs.getBoolean("vibration", true)
 
-    Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
-        Spacer(Modifier.height(16.dp))
-        SudokuBoard(board, selected) { row, col ->
-            selected = row to col
+    var board by remember { mutableStateOf(initialBoard.map { it.clone() }.toTypedArray()) }
+    var notes by remember { mutableStateOf(Array(9) { Array(9) { mutableSetOf<Int>() } }) }
+    var selected by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+    var noteMode by remember { mutableStateOf(false) }
+    var time by remember { mutableStateOf(initialTime) }
+    var solved by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(1000)
+            time++
+        }
+    }
+
+    fun save() {
+        prefs.edit()
+            .putString("board", boardToString(board))
+            .putInt("time", time)
+            .apply()
+    }
+
+    fun clearSave() {
+        prefs.edit().remove("board").remove("time").apply()
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("Time: ${time}s")
+            Row {
+                TextButton(onClick = { noteMode = !noteMode }) {
+                    Text(if (noteMode) "Notes On" else "Notes Off")
+                }
+                Spacer(Modifier.width(8.dp))
+                TextButton(onClick = { save() }) { Text("Save") }
+                Spacer(Modifier.width(8.dp))
+                TextButton(onClick = {
+                    clearSave()
+                    onBack()
+                }) { Text("Exit") }
+            }
+        }
+        SudokuBoard(board, notes.map { row -> row.map { it.toSet() }.toTypedArray() }.toTypedArray(), selected) { r, c ->
+            selected = r to c
         }
         Spacer(Modifier.height(16.dp))
         NumberPad { number ->
             selected?.let { (r, c) ->
-                val newBoard = board.map { it.clone() }.toTypedArray()
-                newBoard[r][c] = number
-                board = newBoard
+                if (noteMode) {
+                    val cellNotes = notes[r][c]
+                    if (cellNotes.contains(number)) cellNotes.remove(number) else cellNotes.add(number)
+                    notes = notes.copyOf()
+                } else if (isValidMove(board, r, c, number)) {
+                    val newBoard = board.map { it.clone() }.toTypedArray()
+                    newBoard[r][c] = number
+                    board = newBoard
+                    notes[r][c].clear()
+                    if (vibrationEnabled) {
+                        haptic.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+                    }
+                    if (soundEnabled) {
+                        tone.startTone(ToneGenerator.TONE_DTMF_0, 100)
+                    }
+                    if (isBoardComplete(board)) {
+                        solved = true
+                        clearSave()
+                    }
+                }
             }
+        }
+        AnimatedVisibility(visible = solved, enter = fadeIn(), exit = fadeOut()) {
+            Text("Congratulations!", style = MaterialTheme.typography.headlineMedium)
+        }
+    }
+}
+
+fun isValidMove(board: Array<IntArray>, row: Int, col: Int, value: Int): Boolean {
+    if (board[row][col] != 0) return false
+    for (i in 0 until 9) {
+        if (board[row][i] == value || board[i][col] == value) return false
+    }
+    val sr = row / 3 * 3
+    val sc = col / 3 * 3
+    for (r in sr until sr + 3) {
+        for (c in sc until sc + 3) {
+            if (board[r][c] == value) return false
+        }
+    }
+    return true
+}
+
+fun isBoardComplete(board: Array<IntArray>): Boolean =
+    board.all { row -> row.all { it != 0 } }
+
+@Composable
+fun NumberPad(onNumberSelected: (Int) -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        for (row in listOf(listOf(1, 2, 3), listOf(4, 5, 6), listOf(7, 8, 9))) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                for (n in row) {
+                    Button(onClick = { onNumberSelected(n) }) { Text(n.toString()) }
+                }
+            }
+            Spacer(Modifier.height(8.dp))
         }
     }
 }
 
 @Composable
-fun NumberPad(onNumberSelected: (Int) -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.SpaceEvenly
+fun SettingsScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val prefs = context.getSharedPreferences("sudoku", Context.MODE_PRIVATE)
+    var sound by remember { mutableStateOf(prefs.getBoolean("sound", true)) }
+    var vibration by remember { mutableStateOf(prefs.getBoolean("vibration", true)) }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        for (i in 1..9) {
-            Button(onClick = { onNumberSelected(i) }) {
-                Text(i.toString())
-            }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Sound", modifier = Modifier.weight(1f))
+            Switch(checked = sound, onCheckedChange = {
+                sound = it
+                prefs.edit().putBoolean("sound", it).apply()
+            })
         }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Vibration", modifier = Modifier.weight(1f))
+            Switch(checked = vibration, onCheckedChange = {
+                vibration = it
+                prefs.edit().putBoolean("vibration", it).apply()
+            })
+        }
+        Button(onClick = onBack) { Text("Back") }
     }
 }

--- a/app/src/main/java/com/example/sudokugame/SudokuBoard.kt
+++ b/app/src/main/java/com/example/sudokugame/SudokuBoard.kt
@@ -4,7 +4,8 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -21,15 +22,17 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun SudokuBoard(
     board: Array<IntArray>,
+    notes: Array<Array<Set<Int>>>,
     selected: Pair<Int, Int>?,
     onCellTapped: (Int, Int) -> Unit
 ) {
-    val highlightAlpha by animateFloatAsState(if (selected != null) 0.5f else 0f)
+    val highlightAlpha by animateFloatAsState(if (selected != null) 0.3f else 0f)
 
     Canvas(
         modifier = Modifier
-            .size(300.dp)
-            .background(Color.White)
+            .fillMaxWidth()
+            .aspectRatio(1f)
+            .background(Color.Black)
             .pointerInput(Unit) {
                 detectTapGestures { offset ->
                     val cellSize = size.width / 9
@@ -44,7 +47,7 @@ fun SudokuBoard(
         // Highlight the currently selected cell
         selected?.let { (r, c) ->
             drawRect(
-                color = Color.Blue.copy(alpha = highlightAlpha),
+                color = Color.Gray.copy(alpha = highlightAlpha),
                 topLeft = Offset(c * cellSize, r * cellSize),
                 size = Size(cellSize, cellSize)
             )
@@ -53,14 +56,14 @@ fun SudokuBoard(
         for (i in 0..9) {
             val stroke = if (i % 3 == 0) 4f else 1f
             drawLine(
-                Color.Black,
+                Color.White,
                 start = Offset(i * cellSize, 0f),
                 end = Offset(i * cellSize, size.height),
                 strokeWidth = stroke,
                 cap = StrokeCap.Round
             )
             drawLine(
-                Color.Black,
+                Color.White,
                 start = Offset(0f, i * cellSize),
                 end = Offset(size.width, i * cellSize),
                 strokeWidth = stroke,
@@ -77,8 +80,22 @@ fun SudokuBoard(
                             c * cellSize + cellSize / 2,
                             r * cellSize + cellSize * 0.75f,
                             android.graphics.Paint().apply {
+                                color = android.graphics.Color.WHITE
                                 textAlign = android.graphics.Paint.Align.CENTER
                                 textSize = cellSize * 0.8f
+                            }
+                        )
+                    }
+                } else if (notes[r][c].isNotEmpty()) {
+                    drawIntoCanvas { canvas ->
+                        canvas.nativeCanvas.drawText(
+                            notes[r][c].sorted().joinToString(""),
+                            c * cellSize + cellSize / 2,
+                            r * cellSize + cellSize * 0.4f,
+                            android.graphics.Paint().apply {
+                                color = android.graphics.Color.GRAY
+                                textAlign = android.graphics.Paint.Align.CENTER
+                                textSize = cellSize * 0.3f
                             }
                         )
                     }

--- a/app/src/main/java/com/example/sudokugame/SudokuGenerator.kt
+++ b/app/src/main/java/com/example/sudokugame/SudokuGenerator.kt
@@ -1,3 +1,56 @@
 package com.example.sudokugame
 
+enum class Difficulty { Easy, Medium, Hard }
+
+fun generatePuzzle(difficulty: Difficulty): Array<IntArray> {
+    val easy = arrayOf(
+        intArrayOf(5, 3, 0, 0, 7, 0, 0, 0, 0),
+        intArrayOf(6, 0, 0, 1, 9, 5, 0, 0, 0),
+        intArrayOf(0, 9, 8, 0, 0, 0, 0, 6, 0),
+        intArrayOf(8, 0, 0, 0, 6, 0, 0, 0, 3),
+        intArrayOf(4, 0, 0, 8, 0, 3, 0, 0, 1),
+        intArrayOf(7, 0, 0, 0, 2, 0, 0, 0, 6),
+        intArrayOf(0, 6, 0, 0, 0, 0, 2, 8, 0),
+        intArrayOf(0, 0, 0, 4, 1, 9, 0, 0, 5),
+        intArrayOf(0, 0, 0, 0, 8, 0, 0, 7, 9)
+    )
+
+    val medium = arrayOf(
+        intArrayOf(0, 0, 0, 2, 6, 0, 7, 0, 1),
+        intArrayOf(6, 8, 0, 0, 7, 0, 0, 9, 0),
+        intArrayOf(1, 9, 0, 0, 0, 4, 5, 0, 0),
+        intArrayOf(8, 2, 0, 1, 0, 0, 0, 4, 0),
+        intArrayOf(0, 0, 4, 6, 0, 2, 9, 0, 0),
+        intArrayOf(0, 5, 0, 0, 0, 3, 0, 2, 8),
+        intArrayOf(0, 0, 9, 3, 0, 0, 0, 7, 4),
+        intArrayOf(0, 4, 0, 0, 5, 0, 0, 3, 6),
+        intArrayOf(7, 0, 3, 0, 1, 8, 0, 0, 0)
+    )
+
+    val hard = arrayOf(
+        intArrayOf(0, 0, 0, 0, 0, 0, 0, 1, 2),
+        intArrayOf(0, 0, 0, 0, 0, 3, 0, 8, 5),
+        intArrayOf(0, 0, 1, 0, 2, 0, 0, 0, 0),
+        intArrayOf(0, 0, 0, 5, 0, 7, 0, 0, 0),
+        intArrayOf(0, 0, 4, 0, 0, 0, 1, 0, 0),
+        intArrayOf(0, 9, 0, 0, 0, 0, 0, 0, 0),
+        intArrayOf(5, 0, 0, 0, 0, 0, 0, 7, 3),
+        intArrayOf(0, 0, 2, 0, 1, 0, 0, 0, 0),
+        intArrayOf(0, 0, 0, 0, 4, 0, 0, 0, 9)
+    )
+
+    val puzzle = when (difficulty) {
+        Difficulty.Easy -> easy
+        Difficulty.Medium -> medium
+        Difficulty.Hard -> hard
+    }
+    return puzzle.map { it.clone() }.toTypedArray()
+}
+
 fun generateEmptyBoard(): Array<IntArray> = Array(9) { IntArray(9) { 0 } }
+
+fun boardToString(board: Array<IntArray>): String =
+    board.joinToString(";") { row -> row.joinToString(",") }
+
+fun stringToBoard(str: String): Array<IntArray> =
+    str.split(";").map { row -> row.split(",").map { it.toInt() }.toIntArray() }.toTypedArray()

--- a/app/src/main/java/com/example/sudokugame/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/sudokugame/ui/theme/Theme.kt
@@ -1,16 +1,25 @@
 package com.example.sudokugame.ui.theme
 
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.lightColorScheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.Typography
+import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.Composable
 
-private val LightColors = lightColorScheme()
+private val DarkColors = darkColorScheme(
+    primary = Color.White,
+    onPrimary = Color.Black,
+    background = Color.Black,
+    onBackground = Color.White,
+    surface = Color.Black,
+    onSurface = Color.White
+)
 
 @Composable
 fun SudokuGameTheme(content: @Composable () -> Unit) {
     MaterialTheme(
-        colorScheme = LightColors,
-        typography = androidx.compose.material3.Typography(),
+        colorScheme = DarkColors,
+        typography = Typography(),
         content = content
     )
 }


### PR DESCRIPTION
## Summary
- Add predefined puzzles and helper functions for easy, medium, and hard difficulties
- Introduce dark theme, board notes, timer, and numpad layout for improved UX
- Add save/continue support and configurable sound/vibration settings

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a912bb53d083309bc11b82b7aaab36