### PR TITLE
Add hints, clearing, and conflict highlights for Sudoku

### DIFF
--- a/app/src/main/java/com/example/sudokugame/SudokuBoard.kt
+++ b/app/src/main/java/com/example/sudokugame/SudokuBoard.kt
@@ -17,13 +17,13 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun SudokuBoard(
     board: Array<IntArray>,
     notes: Array<Array<Set<Int>>>,
     selected: Pair<Int, Int>?,
+    conflicts: Set<Pair<Int, Int>>,
     onCellTapped: (Int, Int) -> Unit
 ) {
     val highlightAlpha by animateFloatAsState(if (selected != null) 0.3f else 0f)
@@ -43,6 +43,15 @@ fun SudokuBoard(
             }
     ) {
         val cellSize = size.width / 9
+
+        // Highlight conflicting cells
+        conflicts.forEach { (r, c) ->
+            drawRect(
+                color = Color.Red.copy(alpha = 0.5f),
+                topLeft = Offset(c * cellSize, r * cellSize),
+                size = Size(cellSize, cellSize)
+            )
+        }
 
         // Highlight the currently selected cell
         selected?.let { (r, c) ->


### PR DESCRIPTION
## Summary
- Add difficulty tracking and limit number pad to 1-4, 1-6 or 1-9 depending on game mode
- Show conflicting cells in red and allow clearing or hinting moves
- Animate number pad visibility and layout size for smoother gameplay

## Testing
- `./gradlew test` *(fails: Unable to access jarfile /workspace/Sudoku-Game-Android/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_b_68a9150d37ec8330b1f57840dd5ee918