### PR TITLE
Refine Sudoku UI with top bar and control panel

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("androidx.compose.ui:ui:$composeUiVersion")
     implementation("androidx.compose.ui:ui-tooling-preview:$composeUiVersion")
     implementation("androidx.compose.material3:material3:1.2.0")
+    implementation("androidx.compose.material:material-icons-extended:$composeUiVersion")
     implementation("com.google.android.material:material:1.11.0")
     debugImplementation("androidx.compose.ui:ui-tooling:$composeUiVersion")
     testImplementation("junit:junit:4.13.2")


### PR DESCRIPTION
## Summary
- Introduce a new top app bar showing puzzle info and a reset button
- Add a control row with hint, notes toggle, and erase actions
- Simplify number pad with larger grey buttons and include material icons dependency

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aa32082e408330aa10c60a3b92662e