### PR TITLE
Add privacy policy page

### DIFF
--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Sudoku Game Privacy Policy</title>
+</head>
+<body>
+<h1>Privacy Policy for Sudoku Game</h1>
+<p>This open-source Sudoku application does not collect, store, or share any personally identifiable information.</p>
+<p>The game operates entirely offline and does not require network access. All progress and settings are kept on the user's device and are removed when the application is uninstalled.</p>
+<p>We do not use cookies, analytics, or advertising libraries.</p>
+<p>If you have any questions about this policy, please contact the project maintainer via the GitHub repository's issue tracker.</p>
+<p>This policy may be updated from time to time. Please review it periodically for changes.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone HTML privacy policy stating no data collection

## Testing
- `./gradlew test` *(fails: Unable to access jarfile /workspace/Sudoku-Game-Android/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_b_68aa465b13608330baade1dcd90a66d9