### PR TITLE
Integrate AdMob native ads into Sudoku game

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation("androidx.compose.material3:material3:1.2.0")
     implementation("androidx.compose.material:material-icons-extended:$composeUiVersion")
     implementation("com.google.android.material:material:1.11.0")
+    implementation("com.google.android.gms:play-services-ads:22.6.0")
     debugImplementation("androidx.compose.ui:ui-tooling:$composeUiVersion")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.azmath.sudoku">
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
     <application
         android:allowBackup="true"
         android:label="@string/app_name"
@@ -7,6 +11,10 @@
         android:roundIcon="@drawable/ic_launcher_foreground"
         android:supportsRtl="true"
         android:theme="@style/Theme.SudokuGame">
+
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-7087498886582308~3433246805"/>
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/azmath/sudoku/Ads.kt
+++ b/app/src/main/java/com/azmath/sudoku/Ads.kt
@@ -1,0 +1,50 @@
+package com.azmath.sudoku
+
+import android.view.LayoutInflater
+import android.widget.Button
+import android.widget.TextView
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.gms.ads.AdLoader
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.nativead.MediaView
+import com.google.android.gms.ads.nativead.NativeAd
+import com.google.android.gms.ads.nativead.NativeAdOptions
+import com.google.android.gms.ads.nativead.NativeAdView
+
+@Composable
+fun NativeAdComposable(modifier: Modifier = Modifier) {
+    AndroidView(modifier = modifier, factory = { context ->
+        val adView = LayoutInflater.from(context).inflate(R.layout.native_ad, null) as NativeAdView
+
+        val adLoader = AdLoader.Builder(context, "ca-app-pub-7087498886582308/1319021685")
+            .forNativeAd { ad: NativeAd ->
+                populateNativeAdView(ad, adView)
+            }
+            .withNativeAdOptions(NativeAdOptions.Builder().build())
+            .build()
+
+        adLoader.loadAd(AdRequest.Builder().build())
+        adView
+    })
+}
+
+private fun populateNativeAdView(nativeAd: NativeAd, adView: NativeAdView) {
+    val headlineView = adView.findViewById<TextView>(R.id.ad_headline)
+    val bodyView = adView.findViewById<TextView>(R.id.ad_body)
+    val callToActionView = adView.findViewById<Button>(R.id.ad_call_to_action)
+    val mediaView = adView.findViewById<MediaView>(R.id.ad_media)
+
+    adView.headlineView = headlineView
+    adView.bodyView = bodyView
+    adView.callToActionView = callToActionView
+    adView.mediaView = mediaView
+
+    headlineView.text = nativeAd.headline
+    bodyView.text = nativeAd.body
+    callToActionView.text = nativeAd.callToAction
+    mediaView.setMediaContent(nativeAd.mediaContent)
+
+    adView.setNativeAd(nativeAd)
+}

--- a/app/src/main/java/com/azmath/sudoku/MainActivity.kt
+++ b/app/src/main/java/com/azmath/sudoku/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.shape.RoundedCornerShape
 import com.azmath.sudoku.ui.theme.SudokuGameTheme
+import com.google.android.gms.ads.MobileAds
 import kotlinx.coroutines.delay
 import kotlin.math.abs
 
@@ -37,6 +38,7 @@ enum class Screen { Start, Game, Settings }
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        MobileAds.initialize(this) {}
         setContent {
             SudokuGameTheme {
                 Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
@@ -117,39 +119,44 @@ fun StartScreen(
             val time = parts.getOrNull(1)?.toIntOrNull()
             if (score != null && time != null) score to time else null
         } ?: emptyList()
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        Text(
-            text = "Sudoku",
-            style = MaterialTheme.typography.headlineLarge,
-            fontWeight = FontWeight.Bold
-        )
-        Spacer(Modifier.height(24.dp))
-        Row {
-            Button(onClick = { onStart(Difficulty.Easy) }) { Text("Easy") }
-            Spacer(Modifier.width(8.dp))
-            Button(onClick = { onStart(Difficulty.Medium) }) { Text("Medium") }
-            Spacer(Modifier.width(8.dp))
-            Button(onClick = { onStart(Difficulty.Hard) }) { Text("Hard") }
-        }
-        if (hasSaved) {
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier.align(Alignment.Center),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Sudoku",
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(Modifier.height(24.dp))
+            Row {
+                Button(onClick = { onStart(Difficulty.Easy) }) { Text("Easy") }
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = { onStart(Difficulty.Medium) }) { Text("Medium") }
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = { onStart(Difficulty.Hard) }) { Text("Hard") }
+            }
+            if (hasSaved) {
+                Spacer(Modifier.height(16.dp))
+                Button(onClick = onContinue) { Text("Continue") }
+            }
             Spacer(Modifier.height(16.dp))
-            Button(onClick = onContinue) { Text("Continue") }
-        }
-        Spacer(Modifier.height(16.dp))
-        Button(onClick = onSettings) { Text("Settings") }
-        if (scores.isNotEmpty()) {
-            Spacer(Modifier.height(16.dp))
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text("High Scores:")
-                scores.forEachIndexed { index, (s, t) ->
-                    Text("${index + 1}. ${s} pts - ${formatTime(t)}")
+            Button(onClick = onSettings) { Text("Settings") }
+            if (scores.isNotEmpty()) {
+                Spacer(Modifier.height(16.dp))
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("High Scores:")
+                    scores.forEachIndexed { index, (s, t) ->
+                        Text("${index + 1}. ${s} pts - ${formatTime(t)}")
+                    }
                 }
             }
         }
+        NativeAdComposable(modifier = Modifier
+            .align(Alignment.BottomCenter)
+            .fillMaxWidth())
     }
 }
 
@@ -372,6 +379,8 @@ fun GameScreen(
                 }
             }
         })
+        Spacer(modifier = Modifier.weight(1f))
+        NativeAdComposable(modifier = Modifier.fillMaxWidth())
         AnimatedVisibility(visible = showDialog, enter = scaleIn(), exit = scaleOut()) {
             AlertDialog(
                 onDismissRequest = {},

--- a/app/src/main/res/layout/native_ad.xml
+++ b/app/src/main/res/layout/native_ad.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="8dp">
+
+        <TextView
+            android:id="@+id/ad_headline"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="#000000"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <com.google.android.gms.ads.nativead.MediaView
+            android:id="@+id/ad_media"
+            android:layout_width="match_parent"
+            android:layout_height="180dp"
+            android:layout_marginTop="8dp" />
+
+        <TextView
+            android:id="@+id/ad_body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textColor="#000000"
+            android:textSize="14sp" />
+
+        <Button
+            android:id="@+id/ad_call_to_action"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp" />
+    </LinearLayout>
+</com.google.android.gms.ads.nativead.NativeAdView>


### PR DESCRIPTION
## Summary
- add Google Mobile Ads SDK dependency and manifest configuration
- initialize Mobile Ads and create composable for loading native ad unit
- display native ads at bottom of main menu and game board screens

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab63be48c88330a13679b26fd9b350