### PR TITLE
feat: request advertising ID permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- declare the Google Advertising ID permission so Play Console no longer warns about missing declaration

## Testing
- `gradle build` *(fails: SDK location not found, Android SDK missing)*

------
https://chatgpt.com/codex/tasks/task_b_68ab707d70e08330be1bb591adc28ed2